### PR TITLE
Q18

### DIFF
--- a/malloy_queries/18.malloy
+++ b/malloy_queries/18.malloy
@@ -59,5 +59,12 @@ query: cs is catalog_sales + {
       or customer.customer_address.ca_state = 'MS'
     )
     and item.i_item_sk != null
+
+    // TODO: top level results aren't matching up with SQL results
+    // I think its because of the `LEFT JOIN` on demographics here is
+    // an `INNER JOIN` in the SQL version, and in this case, we need to
+    // add a `NULL` filter. Unfortunately the query below seems to crash
+    // DuckDB:
+    // 
     // and customer.customer_demographics.cd_demo_sk != null
 }

--- a/malloy_queries/18.malloy
+++ b/malloy_queries/18.malloy
@@ -1,0 +1,61 @@
+import "tpcds.malloy"
+
+query: cs is catalog_sales + {
+  query: aggregations is {
+    aggregate:
+      agg1 is avg(cs_quantity)
+      agg2 is avg(cs_list_price)
+      agg3 is avg(cs_coupon_amt)
+      agg4 is avg(cs_sales_price)
+      agg5 is avg(cs_net_profit)
+      agg6 is avg(customer.c_birth_year)
+      agg7 is avg(customer_demographics.cd_dep_count)
+  }
+} -> {
+  nest:
+    aggregations
+
+  nest: by_item is {
+    group_by: item.i_item_id
+    nest: aggregations
+    nest: by_country is {
+      group_by: customer.customer_address.ca_country
+      nest: aggregations
+      nest: by_state is {
+        group_by: customer.customer_address.ca_state
+        nest: aggregations
+        nest: by_county is {
+          group_by: customer.customer_address.ca_county
+          nest: aggregations
+          order_by: ca_county
+        }
+        order_by: ca_state
+      }
+      order_by: ca_country
+    }
+    order_by: i_item_id
+    limit: 100
+  }
+
+  where:
+    customer_demographics.cd_gender = 'F'
+    and customer_demographics.cd_education_status = 'Unknown'
+    and (
+      customer.c_birth_month = 1
+      or customer.c_birth_month = 6
+      or customer.c_birth_month = 8
+      or customer.c_birth_month = 9
+      or customer.c_birth_month = 12
+      or customer.c_birth_month = 2
+    )
+    and date_dim.d_year = 1998
+    and (
+      customer.customer_address.ca_state = 'MS'
+      or customer.customer_address.ca_state = 'IN'
+      or customer.customer_address.ca_state = 'ND'
+      or customer.customer_address.ca_state = 'OK'
+      or customer.customer_address.ca_state = 'NM'
+      or customer.customer_address.ca_state = 'VA'
+      or customer.customer_address.ca_state = 'MS'
+    )
+}

--- a/malloy_queries/18.malloy
+++ b/malloy_queries/18.malloy
@@ -58,4 +58,6 @@ query: cs is catalog_sales + {
       or customer.customer_address.ca_state = 'VA'
       or customer.customer_address.ca_state = 'MS'
     )
+    and item.i_item_sk != null
+    // and customer.customer_demographics.cd_demo_sk != null
 }

--- a/malloy_queries/tpcds.malloy
+++ b/malloy_queries/tpcds.malloy
@@ -158,6 +158,8 @@ source: catalog_sales is table('duckdb:../data/catalog_sales.parquet') {
   join_one: ship_date is date_dim with cs_ship_date_sk
   join_one: call_center with cs_call_center_sk
   join_one: catalog_returns on cs_order_number = catalog_returns.cr_order_number
+  join_one: customer_demographics with cs_bill_cdemo_sk
+  join_one: item with cs_item_sk
 
   dimension: channel_category is 'catalog channel'
   dimension: channel_id is concat('catalog_page', catalog_page.cp_catalog_page_id)


### PR DESCRIPTION
Good example of defining a query inline in an ad-hoc source, and re-using that query multiple times in deep `nest` clauses.

The top-level query isn't returning results that are exactly the same.