### PR TITLE
implement query 22

### DIFF
--- a/malloy_queries/22.malloy
+++ b/malloy_queries/22.malloy
@@ -1,0 +1,32 @@
+import "tpcds.malloy"
+
+query: inventory -> {
+  declare: qoh is avg(inv_quantity_on_hand)
+
+  aggregate: qoh
+  nest: by_product_name is {
+    group_by: item.i_product_name
+    aggregate: qoh
+    nest: by_brand is {
+      group_by: item.i_brand
+      aggregate: qoh
+      nest: by_class is {
+        group_by: item.i_class
+        aggregate: qoh
+        nest: by_category is {
+          group_by: item.i_category
+          aggregate: qoh
+          order_by: i_category
+        }
+        order_by: i_class
+      }
+      order_by: i_brand
+    }
+  order_by: i_product_name
+  limit: 100
+  }
+
+  where:
+    date_dim.d_month_seq >= 1200
+    and date_dim.d_month_seq <= 1211
+}


### PR DESCRIPTION
This one was annoying for several reasons:

- The SQL query `order by` clause orders on the aggregate column `qoh`; however, this column is the result of a `GROUP BY ROLLUP` clause, which means the column is ordered by value, despite containing values from multiple levels of granularity. That should be a big no-no -- any `order by` should really only be with respect to a single grain.
- The `GROUP BY ROLLUP` clause is spurious, as far as i can tell. None of the "rolled up" dimensions have more than a single member. I think this just adds a bunch of rows with `NULL` values and makes the result super confusing.

I implemented the Malloy version using nesting, and verified with a few spot-checks that the results are equivalent to the SQL. It's not possible in Malloy to `order by` the `qoh` column in the same way it's done in the SQL query, and I think that's a good thing.