### PR TITLE
implement query 25

### DIFF
--- a/malloy_queries/25.malloy
+++ b/malloy_queries/25.malloy
@@ -1,0 +1,36 @@
+import "tpcds.malloy"
+
+query: store_sales + {
+  join_one: sr is store_returns 
+    on ss_customer_sk = sr.sr_customer_sk
+    and ss_item_sk = sr.sr_item_sk
+    and ss_ticket_number = sr.sr_ticket_number
+
+  join_one: cs is catalog_sales
+    on sr.sr_customer_sk = cs.cs_bill_customer_sk
+    and sr.sr_item_sk = cs.cs_item_sk
+  
+} -> {
+  group_by:
+    item.i_item_id
+    item.i_item_desc
+    store.s_store_id
+    store.s_store_name
+
+  aggregate:
+    store_sales_profit is sum(ss_net_profit)
+    store_returns_loss is sum(sr.sr_net_loss)
+    catalog_sales_profit is sum(cs.cs_net_profit)
+
+  where: 
+    sr.sr_customer_sk != null
+    and cs.cs_bill_customer_sk != null
+    and date_dim.d_year = 2001
+    and date_dim.d_moy = 4
+    and sr.date_dim.d_year = 2001
+    and sr.date_dim.d_moy >= 4
+    and sr.date_dim.d_moy <= 10
+    and cs.date_dim.d_year = 2001
+    and cs.date_dim.d_moy >= 4
+    and cs.date_dim.d_moy <= 10
+}

--- a/sql_queries/25.sql
+++ b/sql_queries/25.sql
@@ -1,3 +1,8 @@
+-- Calculate total store profit, total store returns, and catalog sales net profit
+-- For:
+-- Store sales in April of 2001
+-- Store returns between April and October 2001
+-- and catalog sales of those same items by those returning customers between April and October 2001
 
 SELECT i_item_id ,
        i_item_desc ,


### PR DESCRIPTION
Straightforward query. This one has a similar join between `store_sales` and `store_returns` as query 24, so I tried to refactor to include the join in the `source` definition of `store_sales`; unfortunately the join condition doesn't quite match. Query 25's version has an equality condition on `customer_id`, whereas Q24 does not. This is kind of annoying, and I'm leaving the join out of the model as a result. I suppose I could add the join with all three conditions, then filter out cases where they don't match in Q24.