### PR TITLE
implement query 27

### DIFF
--- a/malloy_queries/27.malloy
+++ b/malloy_queries/27.malloy
@@ -1,0 +1,29 @@
+import "tpcds.malloy"
+
+query: store_sales + {
+  query: aggregations is {
+    aggregate:
+      agg1 is avg(ss_quantity)
+      agg2 is avg(ss_list_price)
+      agg3 is avg(ss_coupon_amt)
+      agg4 is avg(ss_sales_price)
+  }
+} -> aggregations + {
+  nest: by_item is aggregations + {
+    group_by: item.i_item_id
+    order_by: i_item_id
+    limit: 100
+
+    nest: by_state is aggregations + {
+      group_by: store.s_state
+      order_by: s_state
+    }
+  }
+
+  where:
+    customer_demographics.cd_gender = 'M'
+    and customer_demographics.cd_marital_status = 'S'
+    and customer_demographics.cd_education_status = 'College'
+    and date_dim.d_year = 2002
+    and store.s_state = 'TN'
+}

--- a/sql_queries/27.sql
+++ b/sql_queries/27.sql
@@ -1,3 +1,9 @@
+-- calculate avg quantitiy, list price, coupon, sales price
+-- for store sales
+-- grouped by item id and state
+-- purchased by male, single, college educated customers
+-- with a hacky GROUP BY ROLLUP type clause using UNION statements
+
 WITH results AS
   (SELECT i_item_id,
           s_state,


### PR DESCRIPTION
Really weird SQL query. It does a hacky manually constructed `GROUP BY ROLLUP` type operation with some `UNION ALL`s. The rollup doesn't really even make sense, since its grouping by state, but also only filtering down to a single state, so the aggregation with and without `state` are identical.

Malloy version is interesting, in that I define the aggregations once in an ad-hoc extension to the source, and re-use it multiple times in the `nest` clause. As a result the Malloy query is 29 LOC as opposed to 66 LOC for the SQL version.