### PR TITLE
implement query 29

### DIFF
--- a/malloy_queries/25.malloy
+++ b/malloy_queries/25.malloy
@@ -1,15 +1,9 @@
 import "tpcds.malloy"
 
 query: store_sales + {
-  join_one: sr is store_returns 
-    on ss_customer_sk = sr.sr_customer_sk
-    and ss_item_sk = sr.sr_item_sk
-    and ss_ticket_number = sr.sr_ticket_number
-
   join_one: cs is catalog_sales
-    on sr.sr_customer_sk = cs.cs_bill_customer_sk
-    and sr.sr_item_sk = cs.cs_item_sk
-  
+    on store_returns.sr_customer_sk = cs.cs_bill_customer_sk
+    and store_returns.sr_item_sk = cs.cs_item_sk
 } -> {
   group_by:
     item.i_item_id
@@ -19,17 +13,17 @@ query: store_sales + {
 
   aggregate:
     store_sales_profit is sum(ss_net_profit)
-    store_returns_loss is sum(sr.sr_net_loss)
+    store_returns_loss is sum(store_returns.sr_net_loss)
     catalog_sales_profit is sum(cs.cs_net_profit)
 
   where: 
-    sr.sr_customer_sk != null
+    store_returns.sr_customer_sk != null
     and cs.cs_bill_customer_sk != null
     and date_dim.d_year = 2001
     and date_dim.d_moy = 4
-    and sr.date_dim.d_year = 2001
-    and sr.date_dim.d_moy >= 4
-    and sr.date_dim.d_moy <= 10
+    and store_returns.date_dim.d_year = 2001
+    and store_returns.date_dim.d_moy >= 4
+    and store_returns.date_dim.d_moy <= 10
     and cs.date_dim.d_year = 2001
     and cs.date_dim.d_moy >= 4
     and cs.date_dim.d_moy <= 10

--- a/malloy_queries/29.malloy
+++ b/malloy_queries/29.malloy
@@ -1,0 +1,29 @@
+import "tpcds.malloy"
+
+query: store_sales + {
+  join_one: cs is catalog_sales
+    on store_returns.sr_customer_sk = cs.cs_bill_customer_sk
+    and store_returns.sr_item_sk = cs.cs_item_sk
+} -> {
+  group_by:
+    item.i_item_id
+    item.i_item_desc
+    store.s_store_id
+    store.s_store_name
+
+  aggregate:
+    store_sales_quantity is sum(ss_quantity)
+    store_returns_quantity is sum(store_returns.sr_return_quantity)
+    catalog_sales_quantity is sum(cs.cs_quantity)
+
+  where: 
+    store_returns.sr_customer_sk != null
+    and cs.cs_bill_customer_sk != null
+    and date_dim.d_year = 1999
+    and date_dim.d_moy = 9
+    and store_returns.date_dim.d_year = 1999
+    and store_returns.date_dim.d_moy >= 9
+    and store_returns.date_dim.d_moy <= 12
+    and cs.date_dim.d_year >= 1999
+    and cs.date_dim.d_year <= 2001
+}

--- a/malloy_queries/tpcds.malloy
+++ b/malloy_queries/tpcds.malloy
@@ -65,6 +65,31 @@ source: inventory is table('duckdb:../data/inventory.parquet') {
   join_one: warehouse with inv_warehouse_sk
 }
 
+source: store_returns is table('duckdb:../data/store_returns.parquet') {
+  join_one: date_dim with sr_returned_date_sk
+  join_one: store with sr_store_sk
+  join_one: customer with sr_customer_sk
+
+  dimension: channel_category is 'store channel'
+  dimension: channel_id is concat('store', store.s_store_id)
+
+  measure: total_returns is sum(sr_return_amt)
+  measure: avg_returns is avg(sr_return_amt)
+  measure: total_loss is sum(sr_net_loss)
+
+  query: projection is {
+    project:
+      channel_category
+      channel_id
+      customer_sk is sr_customer_sk
+      returned_date_sk is sr_returned_date_sk
+      return_amt is sr_return_amt
+      net_loss is sr_net_loss
+
+    where: store.s_store_id != null
+  }
+}
+
 source: store_sales is table('duckdb:../data/store_sales.parquet') {
   join_one: date_dim with ss_sold_date_sk
   join_one: store with ss_store_sk
@@ -74,6 +99,10 @@ source: store_sales is table('duckdb:../data/store_sales.parquet') {
   join_one: household_demographics with ss_hdemo_sk
   join_one: customer_demographics with ss_cdemo_sk
   join_one: customer_address with ss_addr_sk
+  join_one: store_returns
+    on ss_customer_sk = store_returns.sr_customer_sk
+    and ss_item_sk = store_returns.sr_item_sk
+    and ss_ticket_number = store_returns.sr_ticket_number
 
   dimension: channel_category is 'store channel'
   dimension: channel_id is concat('store', store.s_store_id)
@@ -108,31 +137,6 @@ source: store_sales is table('duckdb:../data/store_sales.parquet') {
     where: store.s_store_id != null
   }
 
-}
-  
-source: store_returns is table('duckdb:../data/store_returns.parquet') {
-  join_one: date_dim with sr_returned_date_sk
-  join_one: store with sr_store_sk
-  join_one: customer with sr_customer_sk
-
-  dimension: channel_category is 'store channel'
-  dimension: channel_id is concat('store', store.s_store_id)
-
-  measure: total_returns is sum(sr_return_amt)
-  measure: avg_returns is avg(sr_return_amt)
-  measure: total_loss is sum(sr_net_loss)
-
-  query: projection is {
-    project:
-      channel_category
-      channel_id
-      customer_sk is sr_customer_sk
-      returned_date_sk is sr_returned_date_sk
-      return_amt is sr_return_amt
-      net_loss is sr_net_loss
-
-    where: store.s_store_id != null
-  }
 }
 
 source: catalog_returns is table('duckdb:../data/catalog_returns.parquet') {

--- a/sql_queries/29.sql
+++ b/sql_queries/29.sql
@@ -1,3 +1,5 @@
+-- Looks almost the same as query 25
+
 SELECT i_item_id,
        i_item_desc,
        s_store_id,


### PR DESCRIPTION
Almost identical to query 25, but just different enough so refactoring doesn't quite make sense.

I did end up pushing the `store_returns` join into the source, so queries 25 and 29 don't both need to use the same ad-hoc join clause. Unfortunately, q24 still needs to have the ad-hoc join, since it excludes the `customer_sk` condition on the join.